### PR TITLE
minor simplification of configuration

### DIFF
--- a/config/vufind/DAIA2.ini
+++ b/config/vufind/DAIA2.ini
@@ -1,3 +1,3 @@
 [Global]
 daiaurl = "https://daia.ibs-bw.de/isil/DE-Frei129"
-daiafield = "ppn"
+daiaidprefix = "ppn:"

--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA2.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA2.php
@@ -55,7 +55,7 @@ class DAIA2 extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfac
 	 *
 	 * @var string
 	 */
-	protected $daiaidprefix="ppn";
+	protected $daiaidprefix;
 
 	/**
 	 * HTTP service

--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA2.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA2.php
@@ -58,11 +58,11 @@ class DAIA2 extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfac
 	protected $daiaformat="json";
 
 	/**
-	 * daia query field 
+	 * daia query identifier prefix
 	 *
 	 * @var string
 	 */
-	protected $daiafield="ppn";
+	protected $daiaidprefix="ppn";
 
 	/**
 	 * daia query field 
@@ -104,7 +104,7 @@ class DAIA2 extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfac
 		$http_headers = array(
 				"Content-type: application/$this->daiaformat",
 				"Accept: application/$this->daiaformat");
-		$url = $this->daiaurl . "?id=" . $this->daiafield . ":" . $id . "&" . $format;
+		$url = $this->daiaurl . "?id=" . $this->daiaidprefix . $id . "&" . $format;
 		$adapter = new CurlAdapter();
 
 		try {
@@ -140,10 +140,10 @@ class DAIA2 extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfac
 		} else {
 			throw new ILSException('Global/daiaurl configuration needs to be set.');
 		}
-		if (isset($this->config['Global']['daiafield'])) {
-			$this->daiafield = $this->config['Global']['daiafield'];
+		if (isset($this->config['Global']['daiaidprefix'])) {
+			$this->daiaidprefix = $this->config['Global']['daiaidprefix'];
 		} else {
-			throw new ILSException('Global/daiafield configuration needs to be set.');
+            $this->daiaidprefix = "";
 		}
 	}
 

--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA2.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA2.php
@@ -51,26 +51,11 @@ class DAIA2 extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfac
 	protected $daiaurl;
 
 	/**
-	 * daia request format
-	 *
-	 * @var string
-	 */
-	protected $daiaformat="json";
-
-	/**
 	 * daia query identifier prefix
 	 *
 	 * @var string
 	 */
 	protected $daiaidprefix="ppn";
-
-	/**
-	 * daia query field 
-	 *
-	 * @var string
-	 */
-	protected $daiamethod="GET";
-
 
 	/**
 	 * HTTP service
@@ -100,17 +85,16 @@ class DAIA2 extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfac
 	 */
 	protected function doHTTPRequest($id)
 	{
-		$format = "format=" . $this->daiaformat;
 		$http_headers = array(
-				"Content-type: application/$this->daiaformat",
-				"Accept: application/$this->daiaformat");
-		$url = $this->daiaurl . "?id=" . $this->daiaidprefix . $id . "&" . $format;
+				"Content-type: application/json",
+				"Accept: application/json");
+        $url = $this->daiaurl . "?id=" . $this->daiaidprefix . $id . "&format=json";
 		$adapter = new CurlAdapter();
 
 		try {
 			$client = $this->httpService->createClient($url);
 			$client->setHeaders($http_headers);
-			$client->setMethod($this->daiamethod);
+            $client->setMethod("GET");
 			$client->setAdapter($adapter);
 			$result = $client->send();
 		} catch (\Exception $e) {


### PR DESCRIPTION
DAIA2 will use JSON by default, so this can be hard-coded. The id prefix should be optional and it's structure "ppn:" is not common to all DAIA servers.
